### PR TITLE
Add container exit code check before stopping proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0
+	k8s.io/api v0.23.9
 	k8s.io/apimachinery v0.23.9
 	k8s.io/client-go v0.23.9
 )
@@ -33,7 +34,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	k8s.io/api v0.23.9 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -24,6 +24,7 @@ import (
 	"github.com/maksim-paskal/envoy-sidecar-helper/pkg/client"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -97,22 +98,20 @@ func IsContainerStoped() (bool, error) {
 
 	log.Debugf("containers to watch %v", podContainersName)
 
+	states := getTermStates(podContainersName, pod)
+
 	foundContainers := 0
 
-	// check if containers is stopped
-	for _, containerStatus := range pod.Status.ContainerStatuses {
-		for _, podContainerName := range podContainersName {
-			if containerStatus.Name == podContainerName {
-				if term := containerStatus.State.Terminated; term != nil {
-					switch {
-					case *exitZero:
-						if term.ExitCode == 0 {
-							foundContainers++
-						}
-					default:
-						foundContainers++
-					}
+	// check if containers are stopped
+	for _, term := range states {
+		if term != nil {
+			switch {
+			case *exitZero:
+				if term.ExitCode == 0 {
+					foundContainers++
 				}
+			default:
+				foundContainers++
 			}
 		}
 	}
@@ -128,6 +127,26 @@ func IsContainerStoped() (bool, error) {
 
 	// if not all watched containers are stopped, return false
 	return false, errors.Wrap(errContainerStillRunning, containersName)
+}
+
+type termStates map[string]*v1.ContainerStateTerminated
+
+// getTermStates will get container termination states for provided names.
+func getTermStates(names []string, pod *v1.Pod) termStates {
+	states := termStates{}
+
+	for _, podContainerName := range names {
+		states[podContainerName] = nil
+	}
+
+	// get only the states for containers listed
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		if _, ok := states[containerStatus.Name]; ok {
+			states[containerStatus.Name] = containerStatus.State.Terminated
+		}
+	}
+
+	return states
 }
 
 // check is watched containers is stopped.


### PR DESCRIPTION
# Background

I've seen and directly experienced issues where job containers in freshly deployed pods with sidecars could possibly restart during a complex Kubernetes pod deployment startup stabilization due to job container errors not well checked and/or other resources not yet available. Upon initial deployment, if a job container happens to restart, this will register initially as a termination. As a result, I have observed that the envoy-sidecar-helper triggering a stop of the proxy prematurely before the pod deployment is complete due to the job container restart. Then any restarted job container will not be able to make a network connection now that the proxy was stopped in this scenario.

# Proposed provided solution

I added logic for a zero exit code termination check which must be explicitly enabled by the flag `-exit.zero`. When this flag is explicitly used, the `podContainersName` list will then check for a zero exit code before incrementing the existing `foundContainers` counter logic. I'm now experiencing no more premature stopping of my proxies in my complex multi-pod deployments, and restarted jobs containers can complete after restart now that the proxy was not prematurely stopped during cluster stabilization.

*Minor additional change:*
Initially I added the above exit code check logic to the stopped container loop ([see existing](https://github.com/maksim-paskal/envoy-sidecar-helper/blob/35496fa4a6a642e6041b07f33e43feeb89c448a8/pkg/api/api.go#L101-L110)), however running the tests revealed a cyclomatic complexity of 11 against a limit of 10. To help solve for this without changing the test, I moved the looping container termination capture logic to its own function, and now `make test` passes for me.

Please let me know what you think and if you see any issues with this. Thanks for all the work behind this repo!